### PR TITLE
fix: add type hint for typestamp paramters

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -2,12 +2,13 @@ package rds_test
 
 import (
 	"context"
+	"os"
+	"strings"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
 	"github.com/aws/aws-sdk-go-v2/service/rdsdata/types"
-	"github.com/krotscheck/go-rds-driver"
-	"os"
-	"strings"
+	"github.com/jonbretman/go-rds-driver"
 )
 
 var TestMysqlConfig *rds.Config

--- a/config_test.go
+++ b/config_test.go
@@ -1,9 +1,10 @@
 package rds_test
 
 import (
-	"github.com/krotscheck/go-rds-driver"
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	"github.com/jonbretman/go-rds-driver"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func Test_Config(t *testing.T) {

--- a/connection_test.go
+++ b/connection_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"github.com/golang/mock/gomock"
-	"github.com/krotscheck/go-rds-driver"
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/jonbretman/go-rds-driver"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func Test_Connection(t *testing.T) {

--- a/connector_test.go
+++ b/connector_test.go
@@ -2,10 +2,11 @@ package rds_test
 
 import (
 	"context"
-	"github.com/golang/mock/gomock"
-	"github.com/krotscheck/go-rds-driver"
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/jonbretman/go-rds-driver"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func Test_Connector(t *testing.T) {

--- a/dialect.go
+++ b/dialect.go
@@ -3,10 +3,11 @@ package rds
 import (
 	"database/sql/driver"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
-	"github.com/aws/aws-sdk-go-v2/service/rdsdata/types"
 	"reflect"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata/types"
 )
 
 // FieldConverter is a function that converts the passed result row field into the expected type.
@@ -124,7 +125,8 @@ func ConvertNamedValue(arg driver.NamedValue) (value types.SqlParameter, err err
 		}
 	case time.Time:
 		value = types.SqlParameter{
-			Name: &name,
+			Name:     &name,
+			TypeHint: types.TypeHintTimestamp,
 			Value: &types.FieldMemberStringValue{
 				Value: t.Format("2006-01-02 15:04:05.999"),
 			},

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -2,11 +2,12 @@ package rds_test
 
 import (
 	"database/sql/driver"
+	"testing"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rdsdata/types"
-	"github.com/krotscheck/go-rds-driver"
+	"github.com/jonbretman/go-rds-driver"
 	. "github.com/smartystreets/goconvey/convey"
-	"testing"
 )
 
 func Test_Dialect(t *testing.T) {

--- a/driver_test.go
+++ b/driver_test.go
@@ -2,9 +2,10 @@ package rds_test
 
 import (
 	"database/sql"
-	"github.com/krotscheck/go-rds-driver"
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	"github.com/jonbretman/go-rds-driver"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 //go:generate mockgen -package rds_test -destination client_mocks_test.go . AWSClientInterface

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/krotscheck/go-rds-driver
+module github.com/jonbretman/go-rds-driver
 
 go 1.18
 

--- a/rows_test.go
+++ b/rows_test.go
@@ -2,12 +2,13 @@ package rds_test
 
 import (
 	"database/sql/driver"
-	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
-	"github.com/aws/smithy-go/middleware"
-	"github.com/krotscheck/go-rds-driver"
-	. "github.com/smartystreets/goconvey/convey"
 	"io"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/rdsdata"
+	"github.com/aws/smithy-go/middleware"
+	"github.com/jonbretman/go-rds-driver"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func Test_Rows(t *testing.T) {

--- a/statement_test.go
+++ b/statement_test.go
@@ -3,10 +3,11 @@ package rds_test
 import (
 	"context"
 	"database/sql/driver"
-	"github.com/golang/mock/gomock"
-	"github.com/krotscheck/go-rds-driver"
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/jonbretman/go-rds-driver"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func Test_Statement(t *testing.T) {


### PR DESCRIPTION
This fixes an error I ran into trying to insert `time.Time` values.
