### PR TITLE
Add PostgreSQL timestamptz and fractional seconds support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ The RDS Postgres version supported is 13.12. Driver parity is tested using `gith
 | Feature          | Limitation                                                                                                                              |
 | :--------------- | :-------------------------------------------------------------------------------------------------------------------------------------- |
 | Unsigned Int     | Not natively supported by the AWS SDK's Data API, and are all converted to the int64 type. As such large integer values may be lossy.      |
+| `TIMESTAMPTZ`    | The RDS Data API [always returns `TIMESTAMPTZ` values converted to UTC](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api-operations.html), regardless of the original timezone. |
 | Complex Types    | Postgres complex types - in short anything in [section 8.8](https://www.postgresql.org/docs/10/datatype.html) and after, is not supported. |
 
 ## Options

--- a/dialect.go
+++ b/dialect.go
@@ -140,7 +140,7 @@ func ConvertNamedValue(arg driver.NamedValue) (value types.SqlParameter, err err
 			Name:     &name,
 			TypeHint: types.TypeHintTimestamp,
 			Value: &types.FieldMemberStringValue{
-				Value: t.Format("2006-01-02 15:04:05.999"),
+				Value: t.Format("2006-01-02 15:04:05.999999"),
 			},
 		}
 	case nil:

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -91,20 +91,41 @@ func (d *DialectPostgres) GetFieldConverter(columnType string) FieldConverter {
 		return func(field types.Field) (interface{}, error) {
 			timeStringVal := field.(*types.FieldMemberStringValue).Value
 			if d.parseTime {
-				return time.Parse("15:04:05", timeStringVal)
+				return time.Parse("15:04:05.999999", timeStringVal)
 			}
 			return timeStringVal, nil
 		}
 	case "timestamp":
 		return func(field types.Field) (interface{}, error) {
-			t, err := time.Parse("2006-01-02 15:04:05", field.(*types.FieldMemberStringValue).Value)
+			t, err := time.Parse("2006-01-02 15:04:05.999999", field.(*types.FieldMemberStringValue).Value)
 			if err != nil {
 				return nil, err
 			}
 			if d.parseTime {
 				return t, nil
 			}
-			return t.Format(time.RFC3339), nil
+			return t.Format(time.RFC3339Nano), nil
+		}
+	case "timestamptz":
+		// RDS Data API always returns Aurora PostgreSQL timestamptz in UTC
+		// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api-operations.html
+		return func(field types.Field) (interface{}, error) {
+			s := field.(*types.FieldMemberStringValue).Value
+			t, err := time.Parse("2006-01-02 15:04:05.999999-07:00", s)
+			if err != nil {
+				t, err = time.Parse("2006-01-02 15:04:05.999999-07", s)
+			}
+			if err != nil {
+				t, err = time.Parse("2006-01-02 15:04:05.999999", s)
+				if err != nil {
+					return nil, err
+				}
+				t = t.UTC()
+			}
+			if d.parseTime {
+				return t, nil
+			}
+			return t.Format(time.RFC3339Nano), nil
 		}
 	}
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-//go:generate mockgen -package rds_test -destination client_mocks_test.go . AWSClientInterface
+//go:generate go tool github.com/golang/mock/mockgen -package rds_test -destination client_mocks_test.go . AWSClientInterface
 
 func Test_Driver(t *testing.T) {
 	Convey("Driver", t, func() {

--- a/postgresql_test.go
+++ b/postgresql_test.go
@@ -29,9 +29,10 @@ const PostGreSQLCreateTableQuery = "CREATE TABLE IF NOT EXISTS all_types (" +
 	"sql_byte BYTEA," +
 	"sql_date DATE NULL," +
 	"sql_time TIME NULL," +
-	// "sql_timestampz TIMESTAMPZ NULL," +
+	"sql_timestamp TIMESTAMP NULL," +
+	"sql_timestamptz TIMESTAMPTZ NULL," +
 	// "sql_interval INTERVAL NULL," +
-	"sql_timestamp TIMESTAMP NULL)"
+	"sql_uuid UUID)"
 
 const PostgreSQLDropTableQuery = "DROP TABLE all_types;"
 
@@ -49,9 +50,11 @@ type TestPostgreSQLRow struct {
 	Numeric   float64
 	Real      float64
 	Byte      []byte
-	Date      string
-	Time      string
-	Timestamp string
+	Date        string
+	Time        string
+	Timestamp   string
+	Timestamptz string
+	UUID        string
 }
 
 // NewTestPostgreSQLRow to insert into the database
@@ -71,9 +74,11 @@ func NewTestPostgreSQLRow() *TestPostgreSQLRow {
 		Numeric:   23,
 		Real:      33,
 		Byte:      bytes,
-		Date:      time.Now().Format("2006-01-02"),
-		Time:      time.Now().Format("15:04:05"),
-		Timestamp: time.Now().Format("2006-01-02 15:04:05"),
+		Date:        time.Now().Format("2006-01-02"),
+		Time:        time.Now().Format("15:04:05"),
+		Timestamp:   time.Now().Format("2006-01-02 15:04:05.999999"),
+		Timestamptz: time.Now().Format("2006-01-02 15:04:05.999999-07:00"),
+		UUID:        "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
 	}
 
 	return t
@@ -94,9 +99,11 @@ func (r *TestPostgreSQLRow) Scan(row *sql.Rows) error {
 		&r.Numeric,   // Numeric   float64
 		&r.Real,      // Real      float64
 		&r.Byte,      // Byte      []byte
-		&r.Date,      // Date      string
-		&r.Time,      // Time      string
-		&r.Timestamp, // Timestamp string
+		&r.Date,        // Date        string
+		&r.Time,        // Time        string
+		&r.Timestamp,   // Timestamp   string
+		&r.Timestamptz, // Timestamptz string
+		&r.UUID,        // UUID        string
 	)
 }
 
@@ -114,17 +121,19 @@ func (r *TestPostgreSQLRow) Insert(db *sql.DB) (sql.Result, error) {
 		r.Numeric,   // Numeric   float64
 		r.Real,      // Real      float64
 		r.Byte,      // Byte      []byte
-		r.Date,      // Date      string
-		r.Time,      // Time      string
-		r.Timestamp, // Timestamp string
+		r.Date,        // Date        string
+		r.Time,        // Time        string
+		r.Timestamp,   // Timestamp   string
+		r.Timestamptz, // Timestamptz string
+		r.UUID,        // UUID        string
 	}
 	query := "INSERT INTO all_types (" +
 		"sql_boolean," +
 		"sql_char,sql_varchar,sql_text," +
 		"sql_small_int,sql_medium_int,sql_int," +
 		"sql_decimal,sql_numeric,sql_real,sql_byte," +
-		"sql_date,sql_time,sql_timestamp) " +
-		"VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::date,$13::time,$14::date)"
+		"sql_date,sql_time,sql_timestamp,sql_timestamptz,sql_uuid) " +
+		"VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::date,$13::time,$14::timestamp,$15::timestamptz,$16::uuid)"
 	return db.Exec(query, params...)
 }
 
@@ -234,6 +243,15 @@ func Test_Postgresql(t *testing.T) {
 
 					err := rdsRow.Scan(rdsRows)
 					So(err, ShouldBeNil)
+
+					// Normalize timestamptz to UTC since pgx returns local timezone
+					// while RDS Data API always returns UTC
+					rdsTs, err := time.Parse(time.RFC3339Nano, rdsRow.Timestamptz)
+					So(err, ShouldBeNil)
+					localTs, err := time.Parse(time.RFC3339Nano, localRow.Timestamptz)
+					So(err, ShouldBeNil)
+					rdsRow.Timestamptz = rdsTs.UTC().Format(time.RFC3339Nano)
+					localRow.Timestamptz = localTs.UTC().Format(time.RFC3339Nano)
 
 					So(rdsRow, ShouldResemble, localRow)
 				}


### PR DESCRIPTION
## Summary
- Add `timestamptz` converter handling timezone offsets and bare UTC timestamps
  (RDS Data API always returns Aurora PostgreSQL timestamptz in UTC)
- Update `timestamp` and `time` parse formats to handle optional fractional seconds (`.999999`)
- Use `RFC3339Nano` for `timestamp`/`timestamptz` output to preserve microseconds
- Upgrade outbound `time.Time` precision from milliseconds to microseconds
- Fix `go:generate` directive to use `go tool` for mockgen (Go 1.25 compatibility)
- Fix Makefile `AWS_REGION` to match terraform deployment region
- Add test coverage for `timestamptz` column

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Integration tests pass against RDS Aurora PostgreSQL
- [x] Backward compatible: timestamps without fractional seconds still parse correctly

Fixes #10