### PR TITLE
Convert time.Time to UTC before formatting timestamp parameter

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -140,7 +140,7 @@ func ConvertNamedValue(arg driver.NamedValue) (value types.SqlParameter, err err
 			Name:     &name,
 			TypeHint: types.TypeHintTimestamp,
 			Value: &types.FieldMemberStringValue{
-				Value: t.Format("2006-01-02 15:04:05.999999"),
+				Value: t.UTC().Format("2006-01-02 15:04:05.999999"),
 			},
 		}
 	case nil:

--- a/dialect_test.go
+++ b/dialect_test.go
@@ -2,6 +2,8 @@ package rds_test
 
 import (
 	"database/sql/driver"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rdsdata/types"
 	"github.com/krotscheck/go-rds-driver"
@@ -12,6 +14,35 @@ import (
 func Test_Dialect(t *testing.T) {
 
 	Convey("ConvertNamedValue", t, func() {
+
+		Convey("time.Time is formatted as UTC regardless of input timezone", func() {
+			helsinki, _ := time.LoadLocation("Europe/Helsinki") // UTC+2/UTC+3
+			t := time.Date(2024, 3, 15, 14, 30, 45, 123456000, helsinki)
+
+			namedValue := driver.NamedValue{Name: "ts", Value: t}
+			result, err := rds.ConvertNamedValue(namedValue)
+
+			So(err, ShouldBeNil)
+			So(result, ShouldResemble, types.SqlParameter{
+				Name:     aws.String("ts"),
+				TypeHint: types.TypeHintTimestamp,
+				Value:    &types.FieldMemberStringValue{Value: "2024-03-15 12:30:45.123456"},
+			})
+		})
+
+		Convey("time.Time already in UTC is formatted unchanged", func() {
+			t := time.Date(2024, 3, 15, 12, 30, 45, 0, time.UTC)
+
+			namedValue := driver.NamedValue{Name: "ts", Value: t}
+			result, err := rds.ConvertNamedValue(namedValue)
+
+			So(err, ShouldBeNil)
+			So(result, ShouldResemble, types.SqlParameter{
+				Name:     aws.String("ts"),
+				TypeHint: types.TypeHintTimestamp,
+				Value:    &types.FieldMemberStringValue{Value: "2024-03-15 12:30:45"},
+			})
+		})
 
 		Convey("Null Values", func() {
 			var UInt8 []uint8


### PR DESCRIPTION
## Summary

- `ConvertNamedValue` in `dialect.go` now calls `.UTC()` on the incoming `time.Time` value before formatting it as a timestamp string
- The formatted string has no timezone suffix, so MySQL and Aurora PostgreSQL (which default to UTC for naked datetime values) would silently misinterpret timestamps in any other timezone without this conversion
- Tests added to `dialect_test.go` covering a non-UTC input (Europe/Helsinki) and a UTC input

## Test plan

- [ ] `go test ./... -run Test_Dialect` passes — non-UTC time is shifted to UTC in the formatted string, UTC time is unchanged